### PR TITLE
Updated the book class maps

### DIFF
--- a/College/Biology/Biology.yml
+++ b/College/Biology/Biology.yml
@@ -5,7 +5,7 @@ books:
   cnx_id: 185cbf87-c72e-48f5-b51e-f14f21b5eabd
   reading_processing_instructions:
   - css: .multiple-choice, .free-response, .art-exercise, .interactive-embedded-homework,
-      .scientific, .experiment, [data-type="glossary"]
+      .scientific, [data-type="glossary"]
     fragments: []
   - css: .interactive-embedded-reading
     fragments:

--- a/College/College Physics/College Physics with Courseware.yml
+++ b/College/College Physics/College Physics with Courseware.yml
@@ -4,7 +4,9 @@ books:
 - archive_url: https://archive.cnx.org
   cnx_id: 405335a3-7cff-4df2-a9ad-29062a4af261
   reading_processing_instructions:
-  - css: .conceptual-questions, .problems-exercises, .check-understanding, [data-type="glossary"]
+  - css: .conceptual-questions, .problems-exercises, [data-element-type="conceptual-questions"],
+      [data-element-type="problems-exercises"], [data-element-type="check-understanding"],
+      [data-type="glossary"]
     fragments: []
   - css: .phet-explorations-embedded
     fragments:

--- a/College/College Physics/College Physics.yml
+++ b/College/College Physics/College Physics.yml
@@ -4,7 +4,9 @@ books:
 - archive_url: https://archive.cnx.org
   cnx_id: 031da8d3-b525-429c-80cf-6c8ed997733a
   reading_processing_instructions:
-  - css: .conceptual-questions, .problems-exercises, .check-understanding, [data-type="glossary"]
+  - css: .conceptual-questions, .problems-exercises, [data-element-type="conceptual-questions"],
+      [data-element-type="problems-exercises"], [data-element-type="check-understanding"],
+      [data-type="glossary"]
     fragments: []
   - css: .phet-explorations-embedded
     fragments:

--- a/College/Introduction to Sociology 2e/Sociology 2e.yml
+++ b/College/Introduction to Sociology 2e/Sociology 2e.yml
@@ -4,5 +4,7 @@ books:
 - archive_url: https://archive.cnx.org
   cnx_id: 02040312-72c8-441e-a685-20e9333f3e1d
   reading_processing_instructions:
-  - css: .section-quiz, .short-answer, .further-research, [data-type="glossary"]
+  - css: .section-quiz, .short-answer, .further-research, [data-element-type="section-quiz"],
+      [data-element-type="short-answer"], [data-element-type="further-research"],
+      [data-type="glossary"]
     fragments: []


### PR DESCRIPTION
- Removed `.experiment` rule from Biology because that class does not exist at all in the Biology book
- Added `data-element-type` rules for elements in Physics and Sociology that have both a `class` and a `data-element-type`.
- Removed the `.check-understanding` rule because that element _only_ has a `data-element-type` (no `class`)

cc @philschatz @kathi-fletcher @kjdav
